### PR TITLE
Remove debugger statements from tests

### DIFF
--- a/tests/plugin.js
+++ b/tests/plugin.js
@@ -45,7 +45,6 @@ describe('Tests for frontmatter ESLint processor', function() {
     });
 
     it('should remove all frontmatter even if --- is present in frontmatter', function() {
-      debugger;
       var withDashes = fs.readFileSync(getFixturePath("./fixtures/withDashesInFrontMatter.js"), "utf8");
 
       var processed = plugin.processors['.js'].preprocess(withDashes);
@@ -54,7 +53,6 @@ describe('Tests for frontmatter ESLint processor', function() {
     });
 
     it('should not change JS even if --- present in code', function() {
-      debugger;
       var dashesInCode = fs.readFileSync(getFixturePath("./fixtures/dashesInCode.js"), "utf8");
 
       var processed = plugin.processors['.js'].preprocess(dashesInCode);


### PR DESCRIPTION
I left a few `debugger;` statements in the tests by accident. Sorry. This fixes that.

A linter would catch this. :smile: