### PR TITLE
Fix: postprocess reports accurate line numbers (fixes #5)

### DIFF
--- a/lib/processors/frontmatter.js
+++ b/lib/processors/frontmatter.js
@@ -1,32 +1,36 @@
 require('requireindex');
-var _ = require('lodash');
+
+// Track frontmatter for current file
+var state = {
+  frontMatter: null
+};
 
 module.exports = {
 
   // Specify that this processor transforms .js files
   '.js': {
-
     /**
     * @args:
     *   text `str` the text from the given file
-    *   filename `str` the filename of the given file
     * @returns:
-    *   `[str]` a list of strings (one per each line in the file)
+    *   `[str]` a list of strings (one per each "logical file" in the file)
     **/
 
     preprocess: function(text) {
-      // Trim leading and trailing whitespace
-      text = text.replace(/^\s+|\s+$/g, '');
+      state.frontMatter = null;
 
       // Check if the file begins with frontmatter declaration
       if (text.substring(0,3) === '---') {
         // Find end of frontmatter
-        var matchedDashes = /^---$/m.exec(text.slice(3));
+        var matchedDashes = /^---[\r|\n|\r\n]/m.exec(text.slice(3));
 
         if (matchedDashes) {
           var dashStartIndex = matchedDashes.index;
           var sliceIndex = dashStartIndex + matchedDashes[0].length;
-          return [text.slice(sliceIndex + 3).replace(/^\s+/, '')];
+
+          state.frontMatter = text.slice(0, sliceIndex + 3);
+
+          return [text.slice(state.frontMatter.length)];
         }
       }
 
@@ -44,7 +48,25 @@ module.exports = {
     **/
 
     postprocess: function(messages) {
-      return _.flatten(messages);
+      var flattenedMessages = messages[0],
+        linesInFrontMatter,
+        i;
+
+      if (state.frontMatter) {
+        linesInFrontMatter = state.frontMatter
+          .split(/[\r|\n|\r\n]/)
+          .length - 1;   // subtract 1 because frontmatter ends with newline
+
+        for (i = 0; i < flattenedMessages.length; ++i) {
+          flattenedMessages[i].line += linesInFrontMatter;
+
+          if ('endLine' in flattenedMessages[i]) {
+            flattenedMessages[i].endLine += linesInFrontMatter;
+          }
+        }
+      }
+
+      return flattenedMessages;
     },
 
     // Don't autofix lint errors

--- a/tests/fixtures/withLintErrors.js
+++ b/tests/fixtures/withLintErrors.js
@@ -1,0 +1,5 @@
+---
+propertyKey: 'property value'
+---
+
+console.log("foo");   // no-console, line 5, endLine 5

--- a/tests/fixtures/withLintErrorsNoFrontmatter.js
+++ b/tests/fixtures/withLintErrorsNoFrontmatter.js
@@ -1,0 +1,1 @@
+console.log("foo");   // no-console, line 1, endLine 1

--- a/tests/plugin.js
+++ b/tests/plugin.js
@@ -12,7 +12,13 @@ function getFixturePath(relativePath) {
   return path.normalize(path.join(__dirname, relativePath));
 }
 
-describe('Tests for frontmatter ESLint processor', function() {
+function trim(str) {
+  if (!str) return str;
+
+  return str.replace(/^\s+|\s+$/, '');
+}
+
+describe('Frontmatter processor', function() {
 
   // Specify a sample input file
   var sample = fs.readFileSync(getFixturePath('./fixtures/basic.js'), 'utf8');
@@ -33,7 +39,7 @@ describe('Tests for frontmatter ESLint processor', function() {
     cli.addPlugin('frontmatter', plugin);
   });
 
-  describe('the preprocess function', function() {
+  describe('preprocess', function() {
     it('should remove frontmatter', function() {
       var processed = plugin['processors']['.js']['preprocess'](sample)
       var tripleDashes = processed[0].split('---').length;
@@ -50,14 +56,38 @@ describe('Tests for frontmatter ESLint processor', function() {
       var fixturePath = getFixturePath('./fixtures/withDashesInFrontMatter.js');
       var withDashes = fs.readFileSync(fixturePath, 'utf8');
       var processed = plugin.processors['.js'].preprocess(withDashes);
-      processed[0].should.equal('var x;');
+      trim(processed[0]).should.equal('var x;');
     });
 
     it('should not change JS even if --- present in code', function() {
       var fixturePath = getFixturePath('./fixtures/dashesInCode.js');
       var dashesInCode = fs.readFileSync(fixturePath, 'utf8');
       var processed = plugin.processors['.js'].preprocess(dashesInCode);
-      processed[0].should.equal('x --- y;');
+      trim(processed[0]).should.equal('x --- y;');
+    });
+  });
+
+  describe('postprocess', function() {
+    it('should report accurate line numbers in lint messages', function() {
+      var report = cli.executeOnFiles([
+        getFixturePath('./fixtures/withLintErrors.js')
+      ]);
+      var messages = report.results[0].messages;
+      messages.length.should.equal(1);
+      messages[0].ruleId.should.equal('no-console');
+      messages[0].line.should.equal(5);
+      messages[0].endLine.should.equal(5);
+    });
+
+    it('should report accurately even if no frontmatter', function() {
+      var report = cli.executeOnFiles([
+        getFixturePath('./fixtures/withLintErrorsNoFrontmatter.js')
+      ]);
+      var messages = report.results[0].messages;
+      messages.length.should.equal(1);
+      messages[0].ruleId.should.equal('no-console');
+      messages[0].line.should.equal(1);
+      messages[0].endLine.should.equal(1);
     });
   });
 });


### PR DESCRIPTION
Note: I removed the trim logic in the preprocessor, for a couple of reasons:

1. According to the [Jekyll front matter docs](https://jekyllrb.com/docs/frontmatter/), front matter doesn't work if there is even a byte order mark. So I take that to mean any whitespace before the initial `---` will also prevent Jekyll from processing it. Thus I thought it made more sense to only process files with `---` at the very beginning with no leading whitespace.
1. Removing trailing whitespace from the end of the file could create some false positives or negatives in core ESLint rules (e.g., `no-trailing-whitespace`, `eol-last`), which care about trailing whitespace.
1. In general, the preprocessor should try to change the text as little as possible.

I added some postprocess tests as well-- in those cases, I just used the CLIEngine `executeOnFiles` method to simplify things a bit. Let me know if you think anything should change.